### PR TITLE
Fix CodeFlow icon rendering during GitHub navigation

### DIFF
--- a/codeflow.js
+++ b/codeflow.js
@@ -1,150 +1,188 @@
-(function(){
+(function () {
     const EnableDebugging = false;
-        if(EnableDebugging) 
-            console.log("[CodeFlow] Starting");
     const codeflowPngInGithub = "https://github.com/henrik-me/Github-Codeflow-Extension-Edge/blob/master/icons/icon-16x16.png?raw=true";
-    
-    function makeLink(prlink, height) {
-        return " <a id='CodeFlow' href='codeflow:open?pullrequest=" + prlink +
-            "&amp;ref=EdgeExtension' aria-label='Open in CodeFlow' title='Open in CodeFlow'>" +
-            "<img class='v-align-middle' src='" + codeflowPngInGithub + "' height='" + height + "'></a>";
+    const codeflowLinkSelector = "[data-codeflow-link]";
+    const applyDelayMs = 150;
+    const maxInitialRetries = 10;
+
+    var applyTimer = null;
+    var retriesRemaining = maxInitialRetries;
+    var scheduledApplyUsesRetries = false;
+    var lastUrl = document.location.href;
+
+    function debugLog(message) {
+        if (EnableDebugging) {
+            console.log("[CodeFlow] " + message);
+        }
     }
-    
+
+    debugLog("Starting");
+
+    function makeLink(prlink, height) {
+        var link = document.createElement("a");
+        link.setAttribute("data-codeflow-link", "true");
+        link.href = "codeflow:open?pullrequest=" + prlink + "&ref=EdgeExtension";
+        link.setAttribute("aria-label", "Open in CodeFlow");
+        link.title = "Open in CodeFlow";
+
+        var icon = document.createElement("img");
+        icon.className = "v-align-middle";
+        icon.src = codeflowPngInGithub;
+        icon.height = height;
+
+        link.appendChild(icon);
+        return link;
+    }
+
+    function normalizePullRequestUrl(url) {
+        var prlink = url.replace(document.location.hash, "");
+        var filesPosition = prlink.indexOf("/files");
+
+        if (filesPosition !== -1) {
+            prlink = prlink.substring(0, filesPosition);
+        }
+
+        prlink = prlink.replace("/commits", "");
+        prlink = prlink.replace("/checks", "");
+
+        if (prlink.endsWith("/") && prlink.length > 2) {
+            prlink = prlink.substring(0, prlink.length - 1);
+        }
+
+        debugLog("PR Link: " + prlink);
+        return prlink;
+    }
+
+    function ensureLink(lookupContainer, insertTarget, position, prlink, height) {
+        if (!lookupContainer || !insertTarget) {
+            return false;
+        }
+
+        if (lookupContainer.querySelector(codeflowLinkSelector) !== null) {
+            return true;
+        }
+
+        var codeflowElement = document.createElement("span");
+        codeflowElement.appendChild(document.createTextNode(" "));
+        codeflowElement.appendChild(makeLink(prlink, height));
+        insertTarget.insertAdjacentElement(position, codeflowElement);
+        return true;
+    }
+
     // For individual pull request page, commits tab and checks tab
     function ApplyToPullRequest() {
-        if(EnableDebugging) 
-            console.log("[CodeFlow] ApplyToPullRequest");
+        debugLog("ApplyToPullRequest");
+
         var discussionHeaders = document.querySelectorAll('h1[data-component="PH_Title"]');
-        if (discussionHeaders.length > 0)
-        {
-            var discussionHeader = discussionHeaders[0];
-            var prlink = document.location.href;
-            
-            // Link to a specific change: remove # elements as CodeFlow doesn't support this
-            prlink = prlink.replace(document.location.hash, "")
-            
-            // File Tab: Remove the files part of the url as CodeFlow doesn't support that
-            var filesPosition = prlink.indexOf("/files");
-            if (filesPosition !== -1)
-            {
-              prlink = prlink.substring(0, filesPosition);
-            }
-            
-            // Commit and checks tab: remove commit from the link
-            prlink = prlink.replace("/commits", "")
-            prlink = prlink.replace("/checks", "")
-
-            // remove trailing / from link
-            if (prlink.endsWith("/") && prlink.length > 2) {
-                prlink = prlink.substring(0, prlink.length - 1);
-            }
-
-            if(EnableDebugging) 
-                console.log("[CodeFlow] PR Link: " + prlink);
-    
-            var codeflowElement = document.createElement("span");
-            codeflowElement.innerHTML = makeLink(prlink, 27);
-            var headerSpans = discussionHeader.getElementsByTagName("span");
-            if (headerSpans.length > 0) {
-                numberSpan = headerSpans[0];
-                if (headerSpans.length > 1) {
-                    numberSpan = headerSpans[1];
-                }
-                numberSpan.insertAdjacentElement('beforeend', codeflowElement);
-                return true;
-            }
-    
-            if(EnableDebugging)
-                console.log("[CodeFlow] Unable to identify location to insert codeflow element.");
+        if (discussionHeaders.length === 0) {
+            return false;
         }
-        return false;
+
+        var discussionHeader = discussionHeaders[0];
+        var headerSpans = discussionHeader.getElementsByTagName("span");
+        if (headerSpans.length === 0) {
+            debugLog("Unable to identify location to insert codeflow element.");
+            return false;
+        }
+
+        var numberSpan = headerSpans.length > 1 ? headerSpans[1] : headerSpans[0];
+        return ensureLink(discussionHeader, numberSpan, "beforeend", normalizePullRequestUrl(document.location.href), 27);
     }
-    
+
     // For individual pull request page, commits tab and checks tab, when scrolling down
     function ApplyToPullRequestScrolledDown() {
-        if(EnableDebugging) 
-            console.log("[CodeFlow] ApplyToPullRequestScrolledDown");
+        debugLog("ApplyToPullRequestScrolledDown");
+
         var discussionHeaders = document.querySelectorAll('h2[data-component="PH_Title"]');
-        if (discussionHeaders.length > 0)
-        {
-            var discussionHeader = discussionHeaders[0];
-            var prlink = document.location.href;
-            
-            // Link to a specific change: remove # elements as CodeFlow doesn't support this
-            prlink = prlink.replace(document.location.hash, "")
-            
-            // File Tab: Remove the files part of the url as CodeFlow doesn't support that
-            var filesPosition = prlink.indexOf("/files");
-            if (filesPosition !== -1)
-            {
-              prlink = prlink.substring(0, filesPosition);
-            }
-            
-            // Commit and checks tab: remove commit from the link
-            prlink = prlink.replace("/commits", "")
-            prlink = prlink.replace("/checks", "")
-            if(EnableDebugging) 
-                console.log("[CodeFlow] PR Link: " + prlink);
-    
-            var codeflowElement = document.createElement("span");
-            codeflowElement.innerHTML = makeLink(prlink, 27);
-            discussionHeader.insertAdjacentElement('beforeend', codeflowElement);
-            return true;
+        if (discussionHeaders.length === 0) {
+            return false;
         }
-        return false;
+
+        var discussionHeader = discussionHeaders[0];
+        return ensureLink(discussionHeader, discussionHeader, "beforeend", normalizePullRequestUrl(document.location.href), 27);
     }
-    
+
     // for pull request list page
     function ApplyToPullRequestList() {
-        if(EnableDebugging) 
-            console.log("[CodeFlow] ApplyToPullRequestList");
+        debugLog("ApplyToPullRequestList");
+
         var issueListHeaders = document.getElementsByClassName("js-issue-row");
-        len = issueListHeaders.length;
-        for (var i = 0; i < len; i++) {
-            var id = issueListHeaders[i].id.replace("issue_", "");
-    
-            // Build proper pull URL from the current pulls page URL, ignoring any query string
-            var baseUrl = document.location.origin + document.location.pathname.replace(/\/pulls$/, '/pull');
-            var prlink = makeLink(baseUrl + "/" + id, 16);
-            var codeflowElement = document.createElement("span");
-            codeflowElement.innerHTML = prlink;
-            var titleLink = issueListHeaders[i].getElementsByClassName("js-navigation-open")[0];
-            titleLink.insertAdjacentElement('afterend', codeflowElement);
+        var foundTarget = false;
+        var basePath = document.location.pathname.replace(/\/pulls\/?$/, "/pull");
+        var baseUrl = document.location.origin + basePath;
+
+        for (var i = 0; i < issueListHeaders.length; i++) {
+            var issueListHeader = issueListHeaders[i];
+            var titleLink = issueListHeader.getElementsByClassName("js-navigation-open")[0];
+            var id = issueListHeader.id.replace("issue_", "");
+
+            if (!titleLink || !id) {
+                continue;
+            }
+
+            foundTarget = true;
+            ensureLink(issueListHeader, titleLink, "afterend", baseUrl + "/" + id, 16);
         }
-        return issueListHeaders.length > 0;
+
+        return foundTarget;
     }
-    
-    // apply settigns if the document hasn't already been updated.
+
     function applyLinks() {
-        if (document.hasOwnProperty('codeflowApplied')) {
-            return true;
-        }
-    
-        var result = ApplyToPullRequest() || ApplyToPullRequestList();
-        var result2 = ApplyToPullRequestScrolledDown(); 
-    
-        if (result === true || result2 === true) {
-            document.codeflowApplied = true;
-        }
-    };
-    
-    // Retry to accomodate dynamic content.
-    var retries = 5;
-    function tryUntilSuccess() {
-        if(EnableDebugging) 
-            console.log("[CodeFlow] Try");
-        retries = retries - 1;
-        if (retries == 0) {
-            return;
-        }
-        if (applyLinks() == false) 
-        {
-            if(EnableDebugging) 
-                console.log("[CodeFlow] Re-Try");
-            setTimeout(tryUntilSuccess(), 300);
-        }
+        var foundTarget = false;
+
+        foundTarget = ApplyToPullRequest() || foundTarget;
+        foundTarget = ApplyToPullRequestList() || foundTarget;
+        foundTarget = ApplyToPullRequestScrolledDown() || foundTarget;
+
+        return foundTarget;
     }
-    
-    tryUntilSuccess();
-    })();
-    
+
+    function scheduleApply(useRetries) {
+        scheduledApplyUsesRetries = scheduledApplyUsesRetries || useRetries;
+
+        if (applyTimer !== null) {
+            clearTimeout(applyTimer);
+        }
+
+        applyTimer = setTimeout(function () {
+            applyTimer = null;
+            var retryThisRun = scheduledApplyUsesRetries;
+            scheduledApplyUsesRetries = false;
+
+            if (applyLinks() === false && retryThisRun === true && retriesRemaining > 0) {
+                retriesRemaining = retriesRemaining - 1;
+                debugLog("Re-Try");
+                scheduleApply(true);
+            }
+        }, applyDelayMs);
+    }
+
+    function onNavigationOrDomChange(useRetries) {
+        if (lastUrl !== document.location.href) {
+            lastUrl = document.location.href;
+            retriesRemaining = maxInitialRetries;
+        }
+
+        scheduleApply(useRetries);
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i++) {
+            if (mutations[i].addedNodes.length > 0 || lastUrl !== document.location.href) {
+                onNavigationOrDomChange(false);
+                return;
+            }
+        }
+    });
+
+    if (document.body) {
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    document.addEventListener("pjax:end", function () { onNavigationOrDomChange(true); });
+    document.addEventListener("turbo:render", function () { onNavigationOrDomChange(true); });
+    window.addEventListener("popstate", function () { onNavigationOrDomChange(true); });
+    window.addEventListener("pageshow", function () { onNavigationOrDomChange(true); });
+
+    onNavigationOrDomChange(true);
+})();

--- a/codeflow.js
+++ b/codeflow.js
@@ -4,6 +4,8 @@
     const codeflowLinkSelector = "[data-codeflow-link]";
     const applyDelayMs = 150;
     const maxInitialRetries = 10;
+    const pullRequestPathPattern = /^\/[^\/]+\/[^\/]+\/pull\/\d+(?:\/.*)?$/;
+    const pullRequestListPathPattern = /^\/[^\/]+\/[^\/]+\/pulls\/?$/;
 
     var applyTimer = null;
     var retriesRemaining = maxInitialRetries;
@@ -51,6 +53,11 @@
 
         debugLog("PR Link: " + prlink);
         return prlink;
+    }
+
+    function isSupportedPage() {
+        var path = document.location.pathname;
+        return pullRequestPathPattern.test(path) || pullRequestListPathPattern.test(path);
     }
 
     function ensureLink(lookupContainer, insertTarget, position, prlink, height) {
@@ -128,6 +135,10 @@
     }
 
     function applyLinks() {
+        if (isSupportedPage() === false) {
+            return false;
+        }
+
         var foundTarget = false;
 
         foundTarget = ApplyToPullRequest() || foundTarget;
@@ -158,9 +169,21 @@
     }
 
     function onNavigationOrDomChange(useRetries) {
-        if (lastUrl !== document.location.href) {
+        var urlChanged = lastUrl !== document.location.href;
+
+        if (urlChanged) {
             lastUrl = document.location.href;
             retriesRemaining = maxInitialRetries;
+        }
+
+        if (isSupportedPage() === false) {
+            if (applyTimer !== null) {
+                clearTimeout(applyTimer);
+                applyTimer = null;
+            }
+
+            scheduledApplyUsesRetries = false;
+            return;
         }
 
         scheduleApply(useRetries);
@@ -180,6 +203,7 @@
     }
 
     document.addEventListener("pjax:end", function () { onNavigationOrDomChange(true); });
+    document.addEventListener("turbo:load", function () { onNavigationOrDomChange(true); });
     document.addEventListener("turbo:render", function () { onNavigationOrDomChange(true); });
     window.addEventListener("popstate", function () { onNavigationOrDomChange(true); });
     window.addEventListener("pageshow", function () { onNavigationOrDomChange(true); });

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     
       "content_scripts": [
         {
-          "matches": [ "*://*.github.com/*/pull/*", "*://*.github.com/*/pulls*"],
+          "matches": [ "*://*.github.com/*" ],
           "js": [ "codeflow.js" ],
           "run_at": "document_idle"
         }


### PR DESCRIPTION
## What changed
- make CodeFlow icon insertion idempotent instead of relying on a document-wide codeflowApplied flag
- rebuild the injected link with DOM APIs and mark inserted links so repeated runs do not create duplicates
- reapply links after GitHub in-page navigation and delayed DOM updates using navigation listeners, a MutationObserver, and retry scheduling
- broaden content script injection so the script is already loaded on repository pages before GitHub SPA navigation enters /pulls or /pull/...
- gate the runtime logic by current path so non-PR GitHub pages stay idle until navigation reaches a PR list or PR detail surface

## Why
GitHub often updates repository, pull request list, and pull request detail pages without a full reload. The original extension only injected the content script on URLs that already matched /pulls or /pull/..., so navigating from a repository home page into those routes could skip script startup entirely. On top of that, the previous content script only ran once at page load, could keep stale applied state across in-page navigation, and had broken retry scheduling (setTimeout(tryUntilSuccess(), 300) executed immediately instead of scheduling). Those issues together made the icon appear reliably only after F5 in several navigation paths.

## Tooling
This pull request was created by GitHub Copilot CLI using GPT-5.4 and reviewed locally with Opus 4.6.
